### PR TITLE
adds notebook that adds miso tranche2 data to the baseline transmission

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.gpkg filter=lfs diff=lfs merge=lfs -text
 *.ipynb filter=strip_ipynb_output
 *.shp filter=lfs diff=lfs merge=lfs -text
+*.ipynb linguist-vendored

--- a/inputs/transmission/miso_tranche2_aggregate.ipynb
+++ b/inputs/transmission/miso_tranche2_aggregate.ipynb
@@ -1,0 +1,402 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"miso_tranche2_limits.csv\", index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.assign(r_rr = ['-999']*len(df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.drop(columns=['r','rr','geometry_r','geometry_rr','voltage','ll']).rename(columns={'ba_r':'r',\n",
+    "                                                                                      'ba_rr':'rr'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.query(\"r != rr\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for index, row in df.iterrows():\n",
+    "    df.at[index,'r_rr'] = f\"{row.r}-{row.rr}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped = df.set_index(['r','rr']).groupby('r_rr').sum()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped['r'] = [int(r[0]) for r in df_grouped.index.str.split('-').values]\n",
+    "df_grouped['rr'] = [int(r[1]) for r in df_grouped.index.str.split('-').values]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fix_date(x):\n",
+    "    if x > 4000:\n",
+    "        return int(np.ceil(x/2))\n",
+    "    else:\n",
+    "        return int(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped['isd'] = df_grouped['isd'].apply(fix_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "baseline_file = \"transmission_capacity_future_ba_baseline.csv\"\n",
+    "baseline_df = pd.read_csv(baseline_file).fillna(-999)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "baseline_df[['t','MW']] = baseline_df[['t','MW']].astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prepend_p(x):\n",
+    "    return 'p' + str(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped['r'] = df_grouped['r'].apply(prepend_p)\n",
+    "df_grouped['rr'] = df_grouped['rr'].apply(prepend_p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped= df_grouped.assign(status=['Certain']*len(df_grouped),\n",
+    "                  trtype=['AC']*len(df_grouped),\n",
+    "                  notes=['MISO Tranche 2.1']*len(df_grouped))\\\n",
+    "          .reset_index(drop=True)\\\n",
+    "          .rename(columns={'isd':'t'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped[['t','MW']] = df_grouped[['t','MW']].astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>r</th>\n",
+       "      <th>rr</th>\n",
+       "      <th>status</th>\n",
+       "      <th>trtype</th>\n",
+       "      <th>t</th>\n",
+       "      <th>MW</th>\n",
+       "      <th>notes</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>p61</td>\n",
+       "      <td>p62</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1021</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>p61</td>\n",
+       "      <td>p63</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>387</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>p12</td>\n",
+       "      <td>p13</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2011</td>\n",
+       "      <td>1262</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>p12</td>\n",
+       "      <td>p15</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2011</td>\n",
+       "      <td>765</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>p60</td>\n",
+       "      <td>p63</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2011</td>\n",
+       "      <td>606</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>58</th>\n",
+       "      <td># p24</td>\n",
+       "      <td>p25</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>LCC</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>3000</td>\n",
+       "      <td>TransWest Express</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59</th>\n",
+       "      <td># p5</td>\n",
+       "      <td>p15</td>\n",
+       "      <td>Certain</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>1732</td>\n",
+       "      <td>Boardman to Hemingway</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>60</th>\n",
+       "      <td>### ^^^</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>61</th>\n",
+       "      <td>p80</td>\n",
+       "      <td>p104</td>\n",
+       "      <td>Possible</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>Allows Chicago to connect to rest of PJM</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>62</th>\n",
+       "      <td>p104</td>\n",
+       "      <td>p111</td>\n",
+       "      <td>Possible</td>\n",
+       "      <td>AC</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>Allows SW Michigan to connect to rest of PJM</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>63 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          r    rr    status trtype     t      MW  \\\n",
+       "0       p61   p62   Certain     AC  2010    1021   \n",
+       "1       p61   p63   Certain     AC  2010     387   \n",
+       "2       p12   p13   Certain     AC  2011    1262   \n",
+       "3       p12   p15   Certain     AC  2011     765   \n",
+       "4       p60   p63   Certain     AC  2011     606   \n",
+       "..      ...   ...       ...    ...   ...     ...   \n",
+       "58    # p24   p25   Certain    LCC  2030    3000   \n",
+       "59     # p5   p15   Certain     AC  2030    1732   \n",
+       "60  ### ^^^  -999      -999   -999  -999    -999   \n",
+       "61      p80  p104  Possible     AC     0  100000   \n",
+       "62     p104  p111  Possible     AC     0  100000   \n",
+       "\n",
+       "                                           notes  \n",
+       "0                                           -999  \n",
+       "1                                           -999  \n",
+       "2                                           -999  \n",
+       "3                                           -999  \n",
+       "4                                           -999  \n",
+       "..                                           ...  \n",
+       "58                             TransWest Express  \n",
+       "59                         Boardman to Hemingway  \n",
+       "60                                          -999  \n",
+       "61      Allows Chicago to connect to rest of PJM  \n",
+       "62  Allows SW Michigan to connect to rest of PJM  \n",
+       "\n",
+       "[63 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updated_baseline = pd.concat([baseline_df, df_grouped])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updated_baseline = updated_baseline.fillna(-999).replace(-999, \"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updated_baseline.to_csv(baseline_file, index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pypsa-illinois02",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/inputs/transmission/transmission_capacity_future_ba_baseline.csv
+++ b/inputs/transmission/transmission_capacity_future_ba_baseline.csv
@@ -1,64 +1,85 @@
 r,rr,status,trtype,t,MW,notes
-p61,p62,Certain,AC,2010,1021
-p61,p63,Certain,AC,2010,387
-p12,p13,Certain,AC,2011,1262
-p12,p15,Certain,AC,2011,765
-p60,p63,Certain,AC,2011,606
-p99,p100,Certain,AC,2011,2706
-p100,p116,Certain,AC,2011,2308
-p115,p116,Certain,AC,2011,2077
-p2,p5,Certain,AC,2012,1275
-p40,p53,Certain,AC,2012,514
-p60,p61,Certain,AC,2012,493
-p61,p63,Certain,AC,2012,387
-p12,p13,Certain,AC,2013,1262
-p50,p51,Certain,AC,2013,866
-p60,p63,Certain,AC,2013,1819
-p61,p62,Certain,AC,2013,1021
-p61,p64,Certain,AC,2013,418
-p79,p80,Certain,AC,2013,772
-p131,p132,Certain,AC,2013,1098
-p43,p46,Certain,AC,2014,839
-p48,p50,Certain,AC,2014,908
-p49,p50,Certain,AC,2014,460
-p2,p5,Certain,AC,2015,1275
-p37,p43,Certain,AC,2015,402
-p38,p44,Certain,AC,2015,490
-p43,p44,Certain,AC,2015,615
-p45,p69,Certain,AC,2015,648
-p111,p115,Certain,AC,2015,836
-p122,p126,Certain,AC,2015,2140
-p131,p133,Certain,AC,2015,1479
-p132,p133,Certain,AC,2015,1104
-p45,p68,Certain,AC,2016,704
-p41,p54,Certain,AC,2017,665
-p46,p78,Certain,AC,2018,549
-p70,p71,Certain,AC,2018,797
-p71,p81,Certain,AC,2018,736
-p81,p82,Certain,AC,2018,1074
-p82,p83,Certain,AC,2018,1055
-p105,p107,Certain,AC,2018,4385
-p36,p38,Certain,AC,2019,464
-p5,p7,Certain,AC,2020,1974
-p7,p15,Certain,AC,2020,1215
-p42,p43,Certain,AC,2020,654
-p83,p105,Certain,AC,2020,710
-p10,p28,Possible,AC,2023,970
-p15,p16,Possible,AC,2024,1391
-p16,p21,Possible,AC,2024,1624
-p21,p24,Possible,AC,2024,3026
-p21,p33,Possible,AC,2024,1023
-p25,p26,Possible,AC,2024,2046
-p26,p33,Possible,AC,2024,1088
-p28,p31,Possible,AC,2025,3000
-p5,p15,Possible,AC,2026,1100
-### vvv The next lines are prospective lines; they were used for the National
-### Transmission Planning study but are turned off by default
+p61,p62,Certain,AC,2010,1021,
+p61,p63,Certain,AC,2010,387,
+p12,p13,Certain,AC,2011,1262,
+p12,p15,Certain,AC,2011,765,
+p60,p63,Certain,AC,2011,606,
+p99,p100,Certain,AC,2011,2706,
+p100,p116,Certain,AC,2011,2308,
+p115,p116,Certain,AC,2011,2077,
+p2,p5,Certain,AC,2012,1275,
+p40,p53,Certain,AC,2012,514,
+p60,p61,Certain,AC,2012,493,
+p61,p63,Certain,AC,2012,387,
+p12,p13,Certain,AC,2013,1262,
+p50,p51,Certain,AC,2013,866,
+p60,p63,Certain,AC,2013,1819,
+p61,p62,Certain,AC,2013,1021,
+p61,p64,Certain,AC,2013,418,
+p79,p80,Certain,AC,2013,772,
+p131,p132,Certain,AC,2013,1098,
+p43,p46,Certain,AC,2014,839,
+p48,p50,Certain,AC,2014,908,
+p49,p50,Certain,AC,2014,460,
+p2,p5,Certain,AC,2015,1275,
+p37,p43,Certain,AC,2015,402,
+p38,p44,Certain,AC,2015,490,
+p43,p44,Certain,AC,2015,615,
+p45,p69,Certain,AC,2015,648,
+p111,p115,Certain,AC,2015,836,
+p122,p126,Certain,AC,2015,2140,
+p131,p133,Certain,AC,2015,1479,
+p132,p133,Certain,AC,2015,1104,
+p45,p68,Certain,AC,2016,704,
+p41,p54,Certain,AC,2017,665,
+p46,p78,Certain,AC,2018,549,
+p70,p71,Certain,AC,2018,797,
+p71,p81,Certain,AC,2018,736,
+p81,p82,Certain,AC,2018,1074,
+p82,p83,Certain,AC,2018,1055,
+p105,p107,Certain,AC,2018,4385,
+p36,p38,Certain,AC,2019,464,
+p5,p7,Certain,AC,2020,1974,
+p7,p15,Certain,AC,2020,1215,
+p42,p43,Certain,AC,2020,654,
+p83,p105,Certain,AC,2020,710,
+p10,p28,Possible,AC,2023,970,
+p15,p16,Possible,AC,2024,1391,
+p16,p21,Possible,AC,2024,1624,
+p21,p24,Possible,AC,2024,3026,
+p21,p33,Possible,AC,2024,1023,
+p25,p26,Possible,AC,2024,2046,
+p26,p33,Possible,AC,2024,1088,
+p28,p31,Possible,AC,2025,3000,
+p5,p15,Possible,AC,2026,1100,
+### vvv The next lines are prospective lines; they were used for the National,,,,,,
+### Transmission Planning study but are turned off by default,,,,,,
 # p33,p34,Certain,AC,2030,3274,Colorado Power Pathway (2x 500 kV)
 # p12,p13,Certain,AC,2030,2000,Greenlink Nevada (525 kV)
 # p13,p25,Certain,AC,2030,1600,TransWest Express
 # p24,p25,Certain,LCC,2030,3000,TransWest Express
 # p5,p15,Certain,AC,2030,1732,Boardman to Hemingway
-### ^^^
+### ^^^,,,,,,
 p80,p104,Possible,AC,0,100000,Allows Chicago to connect to rest of PJM
 p104,p111,Possible,AC,0,100000,Allows SW Michigan to connect to rest of PJM
+p105,p103,Certain,AC,2033,4597,MISO Tranche 2.1
+p107,p108,Certain,AC,2032,1173,MISO Tranche 2.1
+p37,p43,Certain,AC,2033,1401,MISO Tranche 2.1
+p38,p68,Certain,AC,2034,4994,MISO Tranche 2.1
+p43,p76,Certain,AC,2034,3139,MISO Tranche 2.1
+p45,p70,Certain,AC,2032,1094,MISO Tranche 2.1
+p68,p43,Certain,AC,2033,8418,MISO Tranche 2.1
+p68,p70,Certain,AC,2034,3333,MISO Tranche 2.1
+p70,p45,Certain,AC,2032,1279,MISO Tranche 2.1
+p70,p80,Certain,AC,2034,3383,MISO Tranche 2.1
+p71,p72,Certain,AC,2032,883,MISO Tranche 2.1
+p72,p81,Certain,AC,2032,3586,MISO Tranche 2.1
+p75,p76,Certain,AC,2032,1279,MISO Tranche 2.1
+p76,p78,Certain,AC,2033,1121,MISO Tranche 2.1
+p76,p79,Certain,AC,2034,4830,MISO Tranche 2.1
+p78,p79,Certain,AC,2033,1279,MISO Tranche 2.1
+p79,p80,Certain,AC,2034,4752,MISO Tranche 2.1
+p80,p105,Certain,AC,2034,4830,MISO Tranche 2.1
+p80,p82,Certain,AC,2032,1147,MISO Tranche 2.1
+p80,p83,Certain,AC,2032,1793,MISO Tranche 2.1
+p81,p72,Certain,AC,2032,1793,MISO Tranche 2.1


### PR DESCRIPTION
This PR adds a notebook that processes the data for MISO tranche 2 by 
* grouping the projects by region
* trimming the projects that are within a single balancing area
* adds the data to the `transmission_capacity_future_ba_baseline.csv` file.