### PR TITLE
Revised d_solveprep to prohibit wind builds in LA

### DIFF
--- a/d_solveprep.gms
+++ b/d_solveprep.gms
@@ -102,6 +102,11 @@ trans_cost_cap_fin_mult_noITC(t) = round(trans_cost_cap_fin_mult_noITC(t),3) ;
 upgrade_derate(i,v,r,t)$upgrade_derate(i,v,r,t) = round(upgrade_derate(i,v,r,t),3) ;
 winter_cap_frac_delta(i,v,r)$winter_cap_frac_delta(i,v,r) = round(winter_cap_frac_delta(i,v,r),3) ;
 
+* Restrict UPV in LA, per PA and SG recommendation - SSS 4/9/25
+Set t_notallowed(t) / 2020*2032 / ;
+m_required_prescriptions("upv",r,t_notallowed)$r_st(r,"LA") = 0 ;
+INV.fx(i,v,r,t_notallowed)$[PV(i)$ r_st(r,'LA')] = 0 ;
+
 
 *================================================
 * --- SEQUENTIAL SETUP ---

--- a/d_solveprep.gms
+++ b/d_solveprep.gms
@@ -104,8 +104,9 @@ winter_cap_frac_delta(i,v,r)$winter_cap_frac_delta(i,v,r) = round(winter_cap_fra
 
 * Restrict UPV in LA, per PA and SG recommendation - SSS 4/9/25
 Set t_notallowed(t) / 2020*2032 / ;
-m_required_prescriptions("upv",r,t_notallowed)$r_st(r,"LA") = 0 ;
-INV.fx(i,v,r,t_notallowed)$[PV(i)$ r_st(r,'LA')] = 0 ;
+m_required_prescriptions("onswind",r,t_notallowed)$r_st(r,"LA") = 0 ;
+m_required_prescriptions("ofswind",r,t_notallowed)$r_st(r,"LA") = 0 ;
+INV.fx(i,v,r,t_notallowed)$[wind(i)$ r_st(r,'LA')] = 0 ;
 
 
 *================================================


### PR DESCRIPTION
Added code to prohibit wind builds in LA until after 2032, per Sam Gomberg and Paul Arbaje's review of near-term builds in LA. Code originally written in 2020 with help from Wesley Cole. Originally these lines were added in d_solveprep after this section: 
recperc(rpscat,st,t) = round(recperc(rpscat,st,t),4) ; 
rsc_fin_mult(i,r,t) = round(rsc_fin_mult(i,r,t),3) ; 
tranloss(r,rr,trtype) = round(tranloss(r,rr,trtype),4) ; 

rsc_fin_mult and tranloss are no longer located in d_solveprep in the 2024 version of ReEDS. I added the new lines after recperc, which is now in the "round parameters" section of d_solveprep. 

## Summary

## Technical Details
### Implementation notes

### Additional changes (if any)

### Switches added/removed/changed (if any)

### Issues resolved (if any)

### Known incompatibilities (if any)

### Relevant sources or documentation (if any)

### Is the model cleaner/better/faster/smaller than before? If so, how?

## Validation / Comparison Report
### Link to report and/or example plots

### (if pertinent) How big is the default run folder (runs/{base}_ref_seq/) before and after the change?

### (if pertinent) What is the run time for ref_seq on the same machine before and after the change?