### PR TITLE
revise d_solveprep to restrict wind builds in LA before 2032

### DIFF
--- a/d_solveprep.gms
+++ b/d_solveprep.gms
@@ -104,8 +104,9 @@ winter_cap_frac_delta(i,v,r)$winter_cap_frac_delta(i,v,r) = round(winter_cap_fra
 
 * Restrict UPV in LA, per PA and SG recommendation - SSS 4/9/25
 Set t_notallowed(t) / 2020*2032 / ;
-m_required_prescriptions("upv",r,t_notallowed)$r_st(r,"LA") = 0 ;
-INV.fx(i,v,r,t_notallowed)$[PV(i)$ r_st(r,'LA')] = 0 ;
+m_required_prescriptions("onswind",r,t_notallowed)$r_st(r,"LA") = 0 ;
+m_required_prescriptions("ofswind",r,t_notallowed)$r_st(r,"LA") = 0 ;
+INV.fx(i,v,r,t_notallowed)$[wind(i)$ r_st(r,'LA')] = 0 ;
 
 
 *================================================


### PR DESCRIPTION
added code to restrict wind builds in LA in d_solveprep Wesley Cole advised to also include restricting the INV.fx (an investment variable found in d2_varfix) from investing in wind in LA for the same time period.

## Summary

## Technical Details
### Implementation notes

### Additional changes (if any)

### Switches added/removed/changed (if any)

### Issues resolved (if any)

### Known incompatibilities (if any)

### Relevant sources or documentation (if any)

### Is the model cleaner/better/faster/smaller than before? If so, how?

## Validation / Comparison Report
### Link to report and/or example plots

### (if pertinent) How big is the default run folder (runs/{base}_ref_seq/) before and after the change?

### (if pertinent) What is the run time for ref_seq on the same machine before and after the change?